### PR TITLE
Remove prefix (Nuclear) docking points for Chemistry questions

### DIFF
--- a/src/ChemicalElement.ts
+++ b/src/ChemicalElement.ts
@@ -82,7 +82,7 @@ export
             // Need to remove this so that we can append the element to mass/proton numbers
             // Renders the mass number first if present, otherwise just renders the element.
             // KaTeX doesn't support the mhchem package so padding is used to display nuclear equations correctly.
-            if (this.dockingPoints["mass_number"].child != null || this.dockingPoints["proton_number"].child != null) {
+            if (this.s.editorMode === "nuclear" && (this.dockingPoints["mass_number"].child != null || this.dockingPoints["proton_number"].child != null)) {
                 expression = "";
                 let mass_number_length = 0;
                 let proton_number_length = 0;
@@ -135,8 +135,8 @@ export
         } else if (format == "mathml") {
             let m_superscript = this.dockingPoints['superscript'].child != null ? "<mrow>" + this.dockingPoints['superscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             let m_subscript = this.dockingPoints['subscript'].child != null ? "<mrow>" + this.dockingPoints['subscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
-            let m_mass_number = this.dockingPoints['mass_number'].child != null ? "<mrow>" + this.dockingPoints['mass_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
-            let m_proton_number = this.dockingPoints['proton_number'].child != null ? "<mrow>" + this.dockingPoints['proton_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
+            let m_mass_number = this.s.editorMode === "nuclear" && this.dockingPoints['mass_number'].child != null ? "<mrow>" + this.dockingPoints['mass_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
+            let m_proton_number = this.s.editorMode === "nuclear" && this.dockingPoints['proton_number'].child != null ? "<mrow>" + this.dockingPoints['proton_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             expression = '';
             if (m_subscript == "<none />" && m_superscript == "<none />" && m_mass_number == "<none />" && m_proton_number == "<none />") {
                 expression += '<mi>' + this.element + '</mi>';
@@ -149,7 +149,7 @@ export
             }
         } else if (format == "mhchem") {
             expression = this.element;
-            if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+            if (this.s.editorMode === "nuclear" && this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                 expression = "";
                 expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.element;
             }

--- a/src/ChemicalElement.ts
+++ b/src/ChemicalElement.ts
@@ -67,8 +67,10 @@ export
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w / 4, -this.s.xBox.h/2), 1, ["chemical_element"], "right");
         this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
         this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
-        this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
-        this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
+        if (this.s.editorMode === "nuclear") {
+            this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
+            this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
+        }
     }
 
     formatExpressionAs(format: string): string {
@@ -202,11 +204,11 @@ export
     }
 
     _shakeIt(): void {
-        // This is how Chemistry works:
-        // ----------------------------------
-        //   mass_number       superscript
-        //              Element            right
-        // proton_number       subscript
+        // This is how Chemistry/(Nuclear Physics) works:
+        // ----------------------------------------------
+        //   (mass_number)       superscript
+        //                Element            right
+        // (proton_number)       subscript
 
         this._shakeItDown();
         let thisBox = this.boundingBox();

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -137,7 +137,7 @@ export
         if (format == "latex") {
             expression = this.latexSymbol;
             //  KaTeX doesn't support the mhchem package so padding is used to align proton number correctly.
-            if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+            if (this.s.editorMode === "nuclear" && this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                 expression = "";
                 let mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
                 let proton_number_length = this.dockingPoints["proton_number"].child.formatExpressionAs(format).length;
@@ -185,7 +185,7 @@ export
             expression = this.mhchemSymbol; // need to remove this so that we can append the element to mass/proton numbers
             // TODO: add support for mass/proton number, decide if we render both simultaneously or separately.
             // Should we render one if the other is ommitted? - for now, no.
-            if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+            if (this.s.editorMode === "nuclear" && this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                 expression = "";
                 expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
             }

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -123,12 +123,13 @@ export
         let descent = this.position.y - (box.y + box.h);
 
         // Create the docking points - added mass number and proton number
-        // TODO: add a flag to toggle the mass/proton number docking points? e.g. boolean nuclearMode
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w/4, -this.s.xBox.h/2), 1, ["particle"], "right");
         this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
         this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
-        this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
-        this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
+        if (this.s.editorMode === "nuclear") {
+            this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
+            this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
+        }
     }
 
     formatExpressionAs(format: string): string {
@@ -232,11 +233,11 @@ export
     }
 
     _shakeIt(): void {
-        // This is how Chemistry works:
-        // ----------------------------------
-        //   mass_number       superscript
-        //              Element            right
-        // proton_number       subscript
+        // This is how Chemistry/(Nuclear Physics) works:
+        // ----------------------------------------------
+        //   (mass_number)       superscript
+        //                Element            right
+        // (proton_number)       subscript
 
         this._shakeItDown();
         let thisBox = this.boundingBox();


### PR DESCRIPTION
Prefixes represent mass and proton numbers. These are only used during Nuclear Physics questions, so can be disabled for ease-of-use in Chemistry questions.

In react-app, we now distinguish between a "chemistry" and "nuclear" `editorMode`. The "mass_number" and "proton_number" docking points are then only instantiated if in nuclear mode.

react-app change [here](https://github.com/isaacphysics/isaac-react-app/pull/1175).