### PR TITLE
Allow Nuclear pre-scripts to be empty in textual form

### DIFF
--- a/src/ChemicalElement.ts
+++ b/src/ChemicalElement.ts
@@ -82,24 +82,25 @@ export
             // Need to remove this so that we can append the element to mass/proton numbers
             // Renders the mass number first if present, otherwise just renders the element.
             // KaTeX doesn't support the mhchem package so padding is used to display nuclear equations correctly.
-            if (this.s.editorMode === "nuclear" && (this.dockingPoints["mass_number"].child != null || this.dockingPoints["proton_number"].child != null)) {
-                expression = "";
-                let mass_number_length = 0;
-                let proton_number_length = 0;
-                if (this.dockingPoints["proton_number"].child != null && this.dockingPoints["mass_number"].child != null) {
-                    proton_number_length = this.dockingPoints["proton_number"].child.formatExpressionAs(format).length;
-                    mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
+            if (this.s.editorMode === "nuclear") {
+                if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    let mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
+                    let proton_number_length = this.dockingPoints["proton_number"].child.formatExpressionAs(format).length;
                     let number_of_spaces = Math.abs(proton_number_length - mass_number_length);
                     let padding = "";
                     // Temporary hack to align mass number and proton number correctly.
                     for (let _i = 0; _i < number_of_spaces; _i++) {
                         padding += "\\enspace";
                     }
-                    expression = (mass_number_length <= proton_number_length) ? "{}^{" + padding + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}\\text{" + this.element + "}" : "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + padding + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}\\text{" + this.element + "}";
+                    expression += (mass_number_length <= proton_number_length) ? "{}^{" + padding + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + "\\text{" + this.element + "}" : 
+                                                                                 "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + padding + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + "\\text{" + this.element + "}";
                 } else if (this.dockingPoints["mass_number"].child != null) {
-                    expression = "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{}\\text{" + this.element + "}";
+                    expression = "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{}" + "\\text{" + this.element + "}";
                 } else if (this.dockingPoints["proton_number"].child != null) {
-                    expression = "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}\\text{" + this.element + "}";
+                    expression = "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + "\\text{" + this.element + "}";
+                } else {
+                    expression ="{}^{}_{}" + "\\text{" + this.element + "}";
                 }
             }
 
@@ -149,9 +150,19 @@ export
             }
         } else if (format == "mhchem") {
             expression = this.element;
-            if (this.s.editorMode === "nuclear" && this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
-                expression = "";
-                expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.element;
+            if (this.s.editorMode === "nuclear") {
+                if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.element;
+                } else if (this.dockingPoints["mass_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{}" + this.element;
+                } else if (this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.element;
+                } else {
+                    expression = "{}^{}_{}" + this.element;
+                }
             }
             if (this.dockingPoints["subscript"].child != null) {
                 expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);

--- a/src/Inequality.ts
+++ b/src/Inequality.ts
@@ -125,10 +125,11 @@ export
     log: Nullable<{ initialState: Array<Object>, actions: Array<Object> }>;
 
     /**
-     * Inequality supports three modes:
+     * Inequality supports four modes:
      * - math
      * - logic (for Boolean Algebra)
      * - chemistry
+     * - nuclear (based on Chemistry)
      * 
      * This should be set from the outside. */
     public editorMode: string;
@@ -259,6 +260,7 @@ export
                 this._baseDockingPointSize = 50/3;
                 break;
             case 'chemistry':
+            case 'nuclear':
                 this._baseFontSize = 50;
                 // I am not sure why we decided to make the docking points smaller for chemistry...
                 this._baseDockingPointSize = 30/3;

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -137,17 +137,26 @@ export
         if (format == "latex") {
             expression = this.latexSymbol;
             //  KaTeX doesn't support the mhchem package so padding is used to align proton number correctly.
-            if (this.s.editorMode === "nuclear" && this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
-                expression = "";
-                let mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
-                let proton_number_length = this.dockingPoints["proton_number"].child.formatExpressionAs(format).length;
-                let number_of_spaces = Math.abs(proton_number_length - mass_number_length);
-                let padding = "";
-                // Temporary hack to align mass number and proton number correctly.
-                for (let _i = 0; _i < number_of_spaces; _i++) {
-                    padding += "\\enspace";
+            if (this.s.editorMode === "nuclear") {
+                if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    let mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
+                    let proton_number_length = this.dockingPoints["proton_number"].child.formatExpressionAs(format).length;
+                    let number_of_spaces = Math.abs(proton_number_length - mass_number_length);
+                    let padding = "";
+                    // Temporary hack to align mass number and proton number correctly.
+                    for (let _i = 0; _i < number_of_spaces; _i++) {
+                        padding += "\\enspace";
+                    }
+                    expression += (mass_number_length <= proton_number_length) ? "{}^{" + padding + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.latexSymbol : 
+                                                                                 "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + padding + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.latexSymbol;
+                } else if (this.dockingPoints["mass_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{}" + this.latexSymbol;
+                } else if (this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.latexSymbol;
                 }
-                expression += (mass_number_length <= proton_number_length) ? "{}^{" + padding + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.latexSymbol : "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + padding + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.latexSymbol;
             }
 
             if (this.dockingPoints["superscript"].child != null) {
@@ -182,12 +191,18 @@ export
         } else if (format == "mathml") {
             expression = '';
         } else if (format == "mhchem") {
-            expression = this.mhchemSymbol; // need to remove this so that we can append the element to mass/proton numbers
-            // TODO: add support for mass/proton number, decide if we render both simultaneously or separately.
-            // Should we render one if the other is ommitted? - for now, no.
-            if (this.s.editorMode === "nuclear" && this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
-                expression = "";
-                expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
+            expression = this.mhchemSymbol;
+            if (this.s.editorMode === "nuclear") {
+                if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
+                } else if (this.dockingPoints["mass_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{}" + this.mhchemSymbol;
+                } else if (this.dockingPoints["proton_number"].child != null) {
+                    expression = "";
+                    expression += "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
+                }
             }
             if (this.dockingPoints["subscript"].child != null) {
                 expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);


### PR DESCRIPTION
In mhchem, Nuclear elements are written in the form `{}^{<mass>}_{<atomic>}<element>` (or similarly).

This change allows `<mass>` or `<atomic>` to be omitted while still returning a valid Particle/ChemicalElement.

e.g. `{}^{4}_{}\alphaparticle`, `{}^{}_{}H`, `{}^{}_{94}Pu`

---

This is used for questions such as [this](https://isaacphysics.org/questions/gcse_ch6_54_q1) which start partially filled, and to allow custom feedback when pre-scripts are missing in a student's answer (rather than the generic syntax error response).