### PR TITLE
Prevent undefined target element in `makeInequality`

### DIFF
--- a/src/Inequality.ts
+++ b/src/Inequality.ts
@@ -1022,7 +1022,7 @@ export
  * This way, p5.js is happy, we are happy, the user is happy, everyone wins!
  */
 export function makeInequality(
-    element: any,
+    element: HTMLElement,
     width: number,
     height: number,
     initialSymbolsToParse: Array<{ type: string, properties: any }> = [],


### PR DESCRIPTION
Updates the type of `makeInequality` to prevent the element being undefined. This would otherwise cause p5 to generate a fullscreen canvas at root level, which is (in our use cases) never intentional behaviour.