### PR TITLE
Remove additional chemistry/nuclear docking points

### DIFF
--- a/src/BinaryOperation.ts
+++ b/src/BinaryOperation.ts
@@ -62,7 +62,7 @@ export
         }
 
         // FIXME Not sure this is entirely right. Maybe make the "type" in DockingPoint an array? Works for now.
-        this.docksTo = ['exponent', 'operator', 'chemical_element', 'state_symbol', 'particle', 'operator_brackets', 'symbol', 'differential', 'top-left', 'bottom-left'];
+        this.docksTo = ['exponent', 'chemical_element', 'state_symbol', 'particle', 'operator_brackets', 'symbol', 'differential', 'top-left', 'bottom-left'];
         if (!["chemistry", "nuclear"].includes(this.s.editorMode)) {
             this.docksTo.push('operator', 'relation');
         }

--- a/src/BinaryOperation.ts
+++ b/src/BinaryOperation.ts
@@ -62,7 +62,10 @@ export
         }
 
         // FIXME Not sure this is entirely right. Maybe make the "type" in DockingPoint an array? Works for now.
-        this.docksTo = ['exponent', 'operator', 'chemical_element', 'state_symbol', 'particle', 'operator_brackets', 'symbol', 'relation', 'differential', 'top-left', 'bottom-left'];
+        this.docksTo = ['exponent', 'operator', 'chemical_element', 'state_symbol', 'particle', 'operator_brackets', 'symbol', 'differential', 'top-left', 'bottom-left'];
+        if (!["chemistry", "nuclear"].includes(this.s.editorMode)) {
+            this.docksTo.push('operator', 'relation');
+        }
     }
 
     get typeAsString(): string {

--- a/src/Brackets.ts
+++ b/src/Brackets.ts
@@ -75,7 +75,10 @@ export
             default:
                 this.latexSymbol = this.mhchemSymbol = this.pythonSymbol = this.mathmlSymbol = { lhs: '', rhs: '' };
         }
-        this.docksTo = ['symbol', 'exponent', 'subscript', 'chemical_element', 'relation', 'differential_argument'];
+        this.docksTo = ['symbol', 'chemical_element', 'relation', 'differential_argument'];
+        if (!['chemistry', 'nuclear'].includes(this.s.editorMode)) {
+            this.docksTo.push('exponent', 'subscript')
+        }
         if (this.s.editorMode != 'logic') {
             this.docksTo.push('operator', 'operator_brackets');
         }
@@ -101,7 +104,7 @@ export
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * this.s.mBox.w/4 + this.scale * 20, -this.s.xBox.h/2), 1, ["operator_brackets"], "right");
         if (this.s.editorMode != 'logic') {
             this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -(box.h + descent + this.scale * 20)), 2/3, ["exponent"], "superscript");
-            if (this.mode == 'chemistry') {
+            if (this.s.editorMode === 'chemistry') {
                 this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -(box.h + descent + this.scale * 20)), 2/3, ["subscript"], "subscript");
             } else {
                 this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -(box.h + descent + this.scale * 20)), 2/3, ["symbol_subscript", "subscript_maths"], "subscript");

--- a/src/Brackets.ts
+++ b/src/Brackets.ts
@@ -76,11 +76,8 @@ export
                 this.latexSymbol = this.mhchemSymbol = this.pythonSymbol = this.mathmlSymbol = { lhs: '', rhs: '' };
         }
         this.docksTo = ['symbol', 'chemical_element', 'relation', 'differential_argument'];
-        if (!['chemistry', 'nuclear'].includes(this.s.editorMode)) {
-            this.docksTo.push('exponent', 'subscript')
-        }
-        if (this.s.editorMode != 'logic') {
-            this.docksTo.push('operator', 'operator_brackets');
+        if (this.s.editorMode === "maths") {
+            this.docksTo.push('exponent', 'subscript', 'operator', 'operator_brackets');
         }
     }
 

--- a/src/ChemicalElement.ts
+++ b/src/ChemicalElement.ts
@@ -65,9 +65,10 @@ export
 
         // Create the docking points
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w / 4, -this.s.xBox.h/2), 1, ["chemical_element"], "right");
-        this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
-        this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
-        if (this.s.editorMode === "nuclear") {
+        if (this.s.editorMode === "chemistry") {
+            this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
+            this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
+        } else if (this.s.editorMode === "nuclear") {
             this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
             this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
         }
@@ -103,12 +104,13 @@ export
                     expression ="{}^{}_{}" + "\\text{" + this.element + "}";
                 }
             }
-
-            if (this.dockingPoints["superscript"].child != null) {
-                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
-            }
-            if (this.dockingPoints["subscript"].child != null) {
-                expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
+            if (this.s.editorMode === "chemistry") {
+                if (this.dockingPoints["superscript"].child != null) {
+                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+                }
+                if (this.dockingPoints["subscript"].child != null) {
+                    expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
+                }
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {
@@ -124,18 +126,20 @@ export
             }
         } else if (format == "subscript") {
             expression = "" + this.element;
-            if (this.dockingPoints["subscript"].child != null) {
-                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-            }
-            if (this.dockingPoints["superscript"].child != null) {
-                expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
+            if (this.s.editorMode === "chemistry") {
+                if (this.dockingPoints["subscript"].child != null) {
+                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
+                }
+                if (this.dockingPoints["superscript"].child != null) {
+                    expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
+                }
             }
             if (this.dockingPoints["right"].child != null) {
                 expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "mathml") {
-            let m_superscript = this.dockingPoints['superscript'].child != null ? "<mrow>" + this.dockingPoints['superscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
-            let m_subscript = this.dockingPoints['subscript'].child != null ? "<mrow>" + this.dockingPoints['subscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
+            let m_superscript = this.s.editorMode === "chemistry" && this.dockingPoints['superscript'].child != null ? "<mrow>" + this.dockingPoints['superscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
+            let m_subscript = this.s.editorMode === "chemistry" && this.dockingPoints['subscript'].child != null ? "<mrow>" + this.dockingPoints['subscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             let m_mass_number = this.s.editorMode === "nuclear" && this.dockingPoints['mass_number'].child != null ? "<mrow>" + this.dockingPoints['mass_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             let m_proton_number = this.s.editorMode === "nuclear" && this.dockingPoints['proton_number'].child != null ? "<mrow>" + this.dockingPoints['proton_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             expression = '';
@@ -164,11 +168,13 @@ export
                     expression = "{}^{}_{}" + this.element;
                 }
             }
-            if (this.dockingPoints["subscript"].child != null) {
-                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-            }
-            if (this.dockingPoints["superscript"].child != null) {
-                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+            if (this.s.editorMode === "chemistry") {
+                if (this.dockingPoints["subscript"].child != null) {
+                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
+                }
+                if (this.dockingPoints["superscript"].child != null) {
+                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+                }
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {

--- a/src/Inequality.ts
+++ b/src/Inequality.ts
@@ -126,7 +126,7 @@ export
 
     /**
      * Inequality supports four modes:
-     * - math
+     * - maths
      * - logic (for Boolean Algebra)
      * - chemistry
      * - nuclear (based on Chemistry)

--- a/src/Num.ts
+++ b/src/Num.ts
@@ -48,7 +48,10 @@ export
         super(p, s);
         this.significand = significand;
 
-        this.docksTo = ['symbol', 'exponent', 'subscript', 'top-left', 'symbol_subscript', 'bottom-left', 'relation', 'operator_brackets', 'differential_order', 'differential_argument'];
+        this.docksTo = ['symbol', 'exponent', 'subscript', 'top-left', 'symbol_subscript', 'bottom-left', 'relation', 'differential_order', 'differential_argument'];
+        if (!["chemistry", "nuclear"].includes(this.s.editorMode)) {
+            this.docksTo.push('operator_brackets');
+        }
     }
 
     get typeAsString(): string {

--- a/src/Num.ts
+++ b/src/Num.ts
@@ -38,7 +38,6 @@ export
      * a number but I can't remember it.
      */
     private significand: string;
-    protected right = this.dockingPoints.hasOwnProperty("right");
     protected superscript = this.dockingPoints.hasOwnProperty("superscript");
 
     get dockingPoint(): p5.Vector {
@@ -49,7 +48,7 @@ export
         super(p, s);
         this.significand = significand;
 
-        this.docksTo = ['symbol', 'exponent', 'subscript', 'top-left', 'symbol_subscript', 'bottom-left', 'particle', 'relation', 'operator_brackets', 'differential_order', 'differential_argument'];
+        this.docksTo = ['symbol', 'exponent', 'subscript', 'top-left', 'symbol_subscript', 'bottom-left', 'relation', 'operator_brackets', 'differential_order', 'differential_argument'];
     }
 
     get typeAsString(): string {
@@ -71,7 +70,9 @@ export
     generateDockingPoints() {
         let box = this.boundingBox();
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w/4, -this.s.xBox.h/2), 1, ["operator"], "right");
-        this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
+        if (this.s.editorMode === "maths") {
+            this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
+        }
     }
 
     formatExpressionAs(format: string): string {
@@ -81,7 +82,7 @@ export
             if (this.superscript && this.dockingPoints["superscript"].child != null) {
                 expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
             }
-            if (this.right && this.dockingPoints["right"].child != null) {
+            if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof Num) {
                     expression += "\\cdot " + this.dockingPoints["right"].child.formatExpressionAs(format);
                 } else {
@@ -93,7 +94,7 @@ export
             if (this.superscript && this.dockingPoints["superscript"].child != null) {
                 expression += "^" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "";
             }
-            if (this.right && this.dockingPoints["right"].child != null) {
+            if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof Num) {
                     expression += "\\cdot " + this.dockingPoints["right"].child.formatExpressionAs(format);
                 } else if (this.dockingPoints["right"].child instanceof BinaryOperation) {
@@ -105,7 +106,7 @@ export
 
         } else if (format == "python") {
             expression = "" + this.getFullText("python");
-            if (this.dockingPoints["superscript"].child != null) {
+            if (this.superscript && this.dockingPoints["superscript"].child != null) {
                 expression += "**(" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + ")";
             }
             if (this.dockingPoints["right"].child != null) {
@@ -120,7 +121,7 @@ export
             }
         } else if (format == "subscript") {
             expression = "" + this.getFullText();
-            if (this.dockingPoints["superscript"].child != null) {
+            if (this.superscript && this.dockingPoints["superscript"].child != null) {
                 expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
             }
             if (this.dockingPoints["right"].child != null) {
@@ -128,12 +129,10 @@ export
             }
         } else if (format == "mathml") {
             expression = '';
-            if (this.dockingPoints['superscript'].child == null) {
-                expression += '<mn>' + this.getFullText() + '</mn>';
-
-            } else {
+            if (this.superscript && this.dockingPoints['superscript'].child != null) {
                 expression += '<msup><mn>' + this.getFullText() + '</mn><mrow>' + this.dockingPoints['superscript'].child.formatExpressionAs(format) + '</mrow></msup>';
-
+            } else {
+                expression += '<mn>' + this.getFullText() + '</mn>';
             }
             if (this.dockingPoints['right'].child != null) {
                 expression += this.dockingPoints['right'].child.formatExpressionAs('mathml');

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -33,6 +33,9 @@ export
     protected particle: string;
     protected mhchemSymbol: string;
 
+    protected massNumber: boolean = this.dockingPoints.hasOwnProperty("mass_number");
+    protected protonNumber: boolean = this.dockingPoints.hasOwnProperty("proton_number");
+
     properties(): Object {
         return {
             particle: this.particle,
@@ -137,7 +140,7 @@ export
         if (format == "latex") {
             expression = this.latexSymbol;
             //  KaTeX doesn't support the mhchem package so padding is used to align proton number correctly.
-            if (this.s.editorMode === "nuclear") {
+            if (this.massNumber && this.protonNumber) {
                 if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                     expression = "";
                     let mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
@@ -192,7 +195,7 @@ export
             expression = '';
         } else if (format == "mhchem") {
             expression = this.mhchemSymbol;
-            if (this.s.editorMode === "nuclear") {
+            if (this.massNumber && this.protonNumber) {
                 if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                     expression = "";
                     expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -124,8 +124,8 @@ export
 
         // Create the docking points - added mass number and proton number
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w/4, -this.s.xBox.h/2), 1, ["particle"], "right");
+        this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
         if (this.s.editorMode === "chemistry") {
-            this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
             this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
         } else if (this.s.editorMode === "nuclear") {
             this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
@@ -161,12 +161,12 @@ export
             }
 
             if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["superscript"].child != null) {
-                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
-                }
                 if (this.dockingPoints["subscript"].child != null) {
                     expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
                 }
+            }
+            if (this.dockingPoints["superscript"].child != null) {
+                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {
@@ -184,9 +184,9 @@ export
                 if (this.dockingPoints["subscript"].child != null) {
                     expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
                 }
-                if (this.dockingPoints["superscript"].child != null) {
-                    expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
-                }
+            }
+            if (this.dockingPoints["superscript"].child != null) {
+                expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
             }
             if (this.dockingPoints["right"].child != null) {
                 expression += this.dockingPoints["right"].child.formatExpressionAs(format);
@@ -213,9 +213,9 @@ export
                 if (this.dockingPoints["subscript"].child != null) {
                     expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
                 }
-                if (this.dockingPoints["superscript"].child != null) {
-                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
-                }
+            }
+            if (this.dockingPoints["superscript"].child != null) {
+                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -33,9 +33,6 @@ export
     protected particle: string;
     protected mhchemSymbol: string;
 
-    protected massNumber: boolean = this.dockingPoints.hasOwnProperty("mass_number");
-    protected protonNumber: boolean = this.dockingPoints.hasOwnProperty("proton_number");
-
     properties(): Object {
         return {
             particle: this.particle,
@@ -127,9 +124,10 @@ export
 
         // Create the docking points - added mass number and proton number
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w/4, -this.s.xBox.h/2), 1, ["particle"], "right");
-        this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
-        this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
-        if (this.s.editorMode === "nuclear") {
+        if (this.s.editorMode === "chemistry") {
+            this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
+            this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
+        } else if (this.s.editorMode === "nuclear") {
             this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
             this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
         }
@@ -140,7 +138,7 @@ export
         if (format == "latex") {
             expression = this.latexSymbol;
             //  KaTeX doesn't support the mhchem package so padding is used to align proton number correctly.
-            if (this.massNumber && this.protonNumber) {
+            if (this.s.editorMode === "nuclear") {
                 if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                     expression = "";
                     let mass_number_length = this.dockingPoints["mass_number"].child.formatExpressionAs(format).length;
@@ -162,11 +160,13 @@ export
                 }
             }
 
-            if (this.dockingPoints["superscript"].child != null) {
-                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
-            }
-            if (this.dockingPoints["subscript"].child != null) {
-                expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
+            if (this.s.editorMode === "chemistry") {
+                if (this.dockingPoints["superscript"].child != null) {
+                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+                }
+                if (this.dockingPoints["subscript"].child != null) {
+                    expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
+                }
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {
@@ -180,11 +180,13 @@ export
                 }
             }
         } else if (format == "subscript") {
-            if (this.dockingPoints["subscript"].child != null) {
-                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-            }
-            if (this.dockingPoints["superscript"].child != null) {
-                expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
+            if (this.s.editorMode === "chemistry") {
+                if (this.dockingPoints["subscript"].child != null) {
+                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
+                }
+                if (this.dockingPoints["superscript"].child != null) {
+                    expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
+                }
             }
             if (this.dockingPoints["right"].child != null) {
                 expression += this.dockingPoints["right"].child.formatExpressionAs(format);
@@ -195,7 +197,7 @@ export
             expression = '';
         } else if (format == "mhchem") {
             expression = this.mhchemSymbol;
-            if (this.massNumber && this.protonNumber) {
+            if (this.s.editorMode === "nuclear") {
                 if (this.dockingPoints["mass_number"].child != null && this.dockingPoints["proton_number"].child != null) {
                     expression = "";
                     expression += "{}^{" + this.dockingPoints["mass_number"].child.formatExpressionAs(format) + "}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
@@ -207,11 +209,13 @@ export
                     expression += "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
                 }
             }
-            if (this.dockingPoints["subscript"].child != null) {
-                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-            }
-            if (this.dockingPoints["superscript"].child != null) {
-                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+            if (this.s.editorMode === "chemistry") {
+                if (this.dockingPoints["subscript"].child != null) {
+                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
+                }
+                if (this.dockingPoints["superscript"].child != null) {
+                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+                }
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -105,7 +105,7 @@ export
             case 'electron':
                 this.particle = 'e';
                 this.pythonSymbol = '\\electron';
-                this.mhchemSymbol = '\\electron';
+                this.mhchemSymbol = 'e';
                 this.latexSymbol = '\\text{e}';
                 break;
             default:

--- a/src/Relation.ts
+++ b/src/Relation.ts
@@ -118,7 +118,10 @@ export
         }
 
         // FIXME Not sure this is entirely right. Maybe make the "type" in DockingPoint an array? Works for now.
-        this.docksTo = ['operator', 'chemical_element', 'state_symbol', 'particle', "operator_brackets"];
+        this.docksTo = ['chemical_element', 'state_symbol', 'particle', "operator_brackets"];
+        if (!["chemistry", "nuclear"].includes(this.s.editorMode)) {
+            this.docksTo.push('operator');
+        }
         // WARNING ^^^ There used to be 'differential in there. Removing it, prevents relations from docking as brackets arguments.
         // THIS MAY BREAK THINGS BUT I CAN'T SEE HOW RIGHT NOW.
         // TODO Check that this doesn't break stuff by accident. If it does, the solution is to exclude it only for logic mode.


### PR DESCRIPTION
This change disables various docking points (the circular points that each widget attaches to) depending on Inequality's `editorMode` being `'chemistry'`/`'nuclear'`. This includes:

- Anything docking to the Exponent of Numbers
- BinaryOperation (plus/minus) docking to Relations (reaction arrows) or to the right of Operators (numbers)
- Brackets docking to Exponent/Subscript slots or to the right of Operators (numbers)
- Numbers docking to the right of Brackets
- _(Nuclear only)_ Anything docking the Exponent/Subscripts of Elements
- _(Nuclear only)_ Anything docking to Subscripts of Particles (Exponents are needed for e.g. positrons)

---

Also changes the text-mode output symbol for electrons from `\electron` to their shorthand `e`.