### PR TITLE
Re-enable several docking points

### DIFF
--- a/src/BinaryOperation.ts
+++ b/src/BinaryOperation.ts
@@ -62,10 +62,7 @@ export
         }
 
         // FIXME Not sure this is entirely right. Maybe make the "type" in DockingPoint an array? Works for now.
-        this.docksTo = ['exponent', 'chemical_element', 'state_symbol', 'particle', 'operator_brackets', 'symbol', 'differential', 'top-left', 'bottom-left', 'operator'];
-        if (!["chemistry", "nuclear"].includes(this.s.editorMode)) {
-            this.docksTo.push('relation');
-        }
+        this.docksTo = ['exponent', 'operator', 'chemical_element', 'state_symbol', 'particle', 'operator_brackets', 'symbol', 'relation', 'differential', 'top-left', 'bottom-left'];
     }
 
     get typeAsString(): string {

--- a/src/Brackets.ts
+++ b/src/Brackets.ts
@@ -75,9 +75,9 @@ export
             default:
                 this.latexSymbol = this.mhchemSymbol = this.pythonSymbol = this.mathmlSymbol = { lhs: '', rhs: '' };
         }
-        this.docksTo = ['symbol', 'chemical_element', 'relation', 'differential_argument'];
-        if (this.s.editorMode === "maths") {
-            this.docksTo.push('exponent', 'subscript', 'operator', 'operator_brackets');
+        this.docksTo = ['symbol', 'exponent', 'subscript', 'chemical_element', 'relation', 'differential_argument']
+        if (this.s.editorMode != 'logic') {
+            this.docksTo.push('operator', 'operator_brackets');
         }
     }
 
@@ -101,7 +101,7 @@ export
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * this.s.mBox.w/4 + this.scale * 20, -this.s.xBox.h/2), 1, ["operator_brackets"], "right");
         if (this.s.editorMode != 'logic') {
             this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -(box.h + descent + this.scale * 20)), 2/3, ["exponent"], "superscript");
-            if (this.s.editorMode === 'chemistry') {
+            if (this.s.editorMode === "chemistry") {
                 this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -(box.h + descent + this.scale * 20)), 2/3, ["subscript"], "subscript");
             } else {
                 this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -(box.h + descent + this.scale * 20)), 2/3, ["symbol_subscript", "subscript_maths"], "subscript");

--- a/src/ChemicalElement.ts
+++ b/src/ChemicalElement.ts
@@ -65,10 +65,9 @@ export
 
         // Create the docking points
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w / 4, -this.s.xBox.h/2), 1, ["chemical_element"], "right");
-        if (this.s.editorMode === "chemistry") {
-            this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
-            this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
-        } else if (this.s.editorMode === "nuclear") {
+        this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
+        this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
+        if (this.s.editorMode === "nuclear") {
             this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
             this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
         }
@@ -104,13 +103,11 @@ export
                     expression ="{}^{}_{}" + "\\text{" + this.element + "}";
                 }
             }
-            if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["superscript"].child != null) {
-                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
-                }
-                if (this.dockingPoints["subscript"].child != null) {
-                    expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
-                }
+            if (this.dockingPoints["superscript"].child != null) {
+                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+            }
+            if (this.dockingPoints["subscript"].child != null) {
+                expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {
@@ -126,20 +123,18 @@ export
             }
         } else if (format == "subscript") {
             expression = "" + this.element;
-            if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["subscript"].child != null) {
-                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-                }
-                if (this.dockingPoints["superscript"].child != null) {
-                    expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
-                }
+            if (this.dockingPoints["subscript"].child != null) {
+                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
+            }
+            if (this.dockingPoints["superscript"].child != null) {
+                expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
             }
             if (this.dockingPoints["right"].child != null) {
                 expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "mathml") {
-            let m_superscript = this.s.editorMode === "chemistry" && this.dockingPoints['superscript'].child != null ? "<mrow>" + this.dockingPoints['superscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
-            let m_subscript = this.s.editorMode === "chemistry" && this.dockingPoints['subscript'].child != null ? "<mrow>" + this.dockingPoints['subscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
+            let m_superscript = this.dockingPoints['superscript'].child != null ? "<mrow>" + this.dockingPoints['superscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
+            let m_subscript = this.dockingPoints['subscript'].child != null ? "<mrow>" + this.dockingPoints['subscript'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             let m_mass_number = this.s.editorMode === "nuclear" && this.dockingPoints['mass_number'].child != null ? "<mrow>" + this.dockingPoints['mass_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             let m_proton_number = this.s.editorMode === "nuclear" && this.dockingPoints['proton_number'].child != null ? "<mrow>" + this.dockingPoints['proton_number'].child.formatExpressionAs(format) + "</mrow>" : "<none />";
             expression = '';
@@ -168,13 +163,12 @@ export
                     expression = "{}^{}_{}" + this.element;
                 }
             }
-            if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["subscript"].child != null) {
-                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-                }
-                if (this.dockingPoints["superscript"].child != null) {
-                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
-                }
+
+            if (this.dockingPoints["subscript"].child != null) {
+                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
+            }
+            if (this.dockingPoints["superscript"].child != null) {
+                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
             }
             if (this.dockingPoints["right"].child != null) {
                 if (this.dockingPoints["right"].child instanceof BinaryOperation) {

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -125,9 +125,8 @@ export
         // Create the docking points - added mass number and proton number
         this.dockingPoints["right"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.s.mBox.w/4, -this.s.xBox.h/2), 1, ["particle"], "right");
         this.dockingPoints["superscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, -this.scale * this.s.mBox.h), 2/3, ["exponent"], "superscript");
-        if (this.s.editorMode === "chemistry") {
-            this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
-        } else if (this.s.editorMode === "nuclear") {
+        this.dockingPoints["subscript"] = new DockingPoint(this, this.p.createVector(box.w/2 + this.scale * 20, descent), 2/3, ["subscript"], "subscript");
+        if (this.s.editorMode === "nuclear") {
             this.dockingPoints["mass_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["top-left"], "mass_number");
             this.dockingPoints["proton_number"] = new DockingPoint(this, this.p.createVector(0, 0), 2/3, ["bottom-left"], "proton_number");
         }
@@ -160,10 +159,8 @@ export
                 }
             }
 
-            if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["subscript"].child != null) {
-                    expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
-                }
+            if (this.dockingPoints["subscript"].child != null) {
+                expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";
             }
             if (this.dockingPoints["superscript"].child != null) {
                 expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
@@ -180,10 +177,8 @@ export
                 }
             }
         } else if (format == "subscript") {
-            if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["subscript"].child != null) {
-                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-                }
+            if (this.dockingPoints["subscript"].child != null) {
+                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
             }
             if (this.dockingPoints["superscript"].child != null) {
                 expression += this.dockingPoints["superscript"].child.formatExpressionAs(format);
@@ -209,10 +204,8 @@ export
                     expression += "{}^{}_{" + this.dockingPoints["proton_number"].child.formatExpressionAs(format) + "}" + this.mhchemSymbol;
                 }
             }
-            if (this.s.editorMode === "chemistry") {
-                if (this.dockingPoints["subscript"].child != null) {
-                    expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
-                }
+            if (this.dockingPoints["subscript"].child != null) {
+                expression += this.dockingPoints["subscript"].child.formatExpressionAs(format);
             }
             if (this.dockingPoints["superscript"].child != null) {
                 expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";


### PR DESCRIPTION
The last Inequality change disabled several docking points that might be used in a way that can't be processed by the chemistry checker but may be associated with certain niche student misconceptions in how answers can be written. This change reverts those disabled points to re-allow those misconceptions.

The following two docking points are still disabled in chemistry/nuclear, but all others are as they were:
- Anything docking to the exponent of Numbers _(known to be confusing with where to put charge)_
- Numbers docking to the right of Brackets _(translates to the same mhchem text as in the subscript, but is invalid)_

---

(**Note: For a question to be made that specifically addresses these misconceptions, inequality's grammar and the chemistry checker must still be changed to allow it first. Currently, it will always lead to *"We are unable to interpret your answer"* feedback**)