### PR TITLE
Expand negative one check to all negatives

### DIFF
--- a/src/BinaryOperation.ts
+++ b/src/BinaryOperation.ts
@@ -81,19 +81,16 @@ export
     }
 
     /**
-     * It is possible to use the binary minus symbol to form -1.
+     * It is possible to use the binary minus symbol to form negative numbers.
      * For nuclear atomic numbers this causes a parsing error because of how
      * binary operators are currently formatted.
      *
       - _right_: right docking point widget to check
      *
      */
-    isSolitaryNegativeOne(right: Nullable<Widget>): boolean {
-        if (right?.typeAsString == "Num") {
-            if ((right as Num).getFullText() === "1" && this.latexSymbol == '-') {
-                return !right.dockingPoints["right"].child
-                    && !right.dockingPoints["superscript"].child;
-            }
+    isSolitaryNegativeNumber(right: Nullable<Widget>): boolean {
+        if (right?.typeAsString == "Num" && this.latexSymbol == '-') {
+            return !right.dockingPoints["right"].child;
         }
         return false;
     }
@@ -101,8 +98,8 @@ export
     formatExpressionAs(format: string): string {
         let expression = " ";
         if (format == "latex") {
-            if (this.isSolitaryNegativeOne(this.dockingPoints["right"].child)) {
-                return "-1";
+            if (["chemistry", "nuclear"].includes(this.s.editorMode) && this.isSolitaryNegativeNumber(this.dockingPoints["right"].child)) {
+                return "-" + (this.dockingPoints["right"].child as Num).getFullText();
             }
 
             expression += this.latexSymbol + " ";
@@ -115,8 +112,8 @@ export
                 expression += "" + this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "mhchem") {
-            if (this.isSolitaryNegativeOne(this.dockingPoints["right"].child)) {
-                return "-1";
+            if (["chemistry", "nuclear"].includes(this.s.editorMode) && this.isSolitaryNegativeNumber(this.dockingPoints["right"].child)) {
+                return "-" + (this.dockingPoints["right"].child as Num).getFullText();
             }
 
           expression += this.mhchemSymbol + " ";


### PR DESCRIPTION
In the Inequality editor for Chem/Nuclear, when a “-1” exists on screen and is using the binary minus symbol (but not when the minus is part of the number directly), items being dragged from the inequality menu will continue to be dragged even when placed.

The line causing this specific problem was 
```
95                    && !right.dockingPoints["superscript"].child;
```
however this also highlights that the `isSolitaryNegativeOne` function around it was outdated and causing inconsistent behaviour. 

All negative numbers are now treated equally in-grammar (they potentially weren't before?), so this change to broaden the function allows more answers to be processed correctly rather than leading to a syntax error.