### PR TITLE
Fix differential detatchability behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inequality",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A symbolic equation editor for the web",
   "private": false,
   "main": "./lib/main.js",

--- a/src/Differential.ts
+++ b/src/Differential.ts
@@ -70,7 +70,7 @@ class Differential extends Widget {
             if (p instanceof Derivative) {
                 return true;
             }
-            p = this.parentWidget;
+            p = p?.parentWidget;
         }
         return false;
     }

--- a/src/Inequality.ts
+++ b/src/Inequality.ts
@@ -472,6 +472,8 @@ export
         // Make sure we have an active docking point, and that the moving symbol can dock to it.
         if (isDefined(this._potentialSymbol) && this._activeDockingPoint != null && _intersection(this._potentialSymbol.docksTo, this._activeDockingPoint.type).length > 0) {
             this._activeDockingPoint.child = this._potentialSymbol;
+            this._activeDockingPoint.child.dockedByUser = true;
+            
             this.log?.actions.push({
                 event: "DOCK_POTENTIAL_SYMBOL",
                 symbol: this._potentialSymbol.subtreeObject(false, true, true),
@@ -836,6 +838,8 @@ export
                 this.updateCanvasDockingPoints();
                 // Do the actual docking
                 this._activeDockingPoint.child = this._movingSymbol;
+                this._activeDockingPoint.child.dockedByUser = true;
+
                 // Let the widget know to which docking point it is docked. This is starting to become ridiculous...
                 this._activeDockingPoint.child.dockedTo = this._activeDockingPoint.name;
 

--- a/src/Inequality.ts
+++ b/src/Inequality.ts
@@ -615,6 +615,10 @@ export
             default: // this would be a Widget and should really never happen...
                 break;
         }
+    
+        if (isDefined(w)) {
+            w.dockedByUser = node.dockedByUser ?? false;
+        }
 
         // By default, this method recursively parses the children of the given node.
         if (isDefined(w) && parseChildren && isDefined(node.children)) {

--- a/src/Num.ts
+++ b/src/Num.ts
@@ -22,6 +22,8 @@ import { BinaryOperation } from "./BinaryOperation";
 import { DockingPoint } from "./DockingPoint";
 import { Relation } from "./Relation";
 import { Inequality } from "./Inequality";
+import { isDefined } from "./utils";
+import { Differential } from "./Differential";
 
 /** A class for representing numbers */
 export
@@ -44,6 +46,16 @@ export
         return this.p.createVector(0, -this.scale*this.s.xBox.h/2);
     }
 
+    /**
+     *  Checks if this symbol is the direct child of a differential.
+     * 
+     * @returns {boolean} True if this symbol is the direct child of a differential but not multiplied to it.
+     */
+    get sonOfADifferential(): boolean {
+        let p = this.parentWidget;
+        return isDefined(p) && p instanceof Differential && this != p.dockingPoints["right"].child;
+    }
+
     constructor(p: p5, s: Inequality, significand: string, _exponent: string) {
         super(p, s);
         this.significand = significand;
@@ -52,6 +64,19 @@ export
         if (!["chemistry", "nuclear"].includes(this.s.editorMode)) {
             this.docksTo.push('operator_brackets');
         }
+    }
+
+    /**
+     * Prevents Nums from being detached from pre-docked Differentials when the user is
+     * unprivileged.
+     * 
+     * On Isaac, only admins and content editors are privileged.
+     * 
+     * @returns True if this symbol is detachable from its parent, false otherwise.
+     */
+    get isDetachable(): boolean {
+        const userIsPrivileged = this.s.isUserPrivileged();
+        return document.location.pathname == '/equality' || userIsPrivileged || this.dockedByUser || !this.sonOfADifferential;
     }
 
     get typeAsString(): string {

--- a/src/Symbol.ts
+++ b/src/Symbol.ts
@@ -94,7 +94,7 @@ export
      */
     get isDetachable(): boolean {
         const userIsPrivileged = this.s.isUserPrivileged();
-        return document.location.pathname == '/equality' || userIsPrivileged || !this.sonOfADifferential;
+        return document.location.pathname == '/equality' || userIsPrivileged || this.dockedByUser || !this.sonOfADifferential;
     }
 
 	/**

--- a/src/Symbol.ts
+++ b/src/Symbol.ts
@@ -124,7 +124,11 @@ export
                 expression += "'"
             }
             if (this.dockingPoints["superscript"] && this.dockingPoints["superscript"].child != null) {
-                expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+                if (this.parentWidget instanceof Differential) {
+                    expression = "(" + expression + "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "})";
+                } else {
+                    expression += "^{" + this.dockingPoints["superscript"].child.formatExpressionAs(format) + "}";
+                }
             }
             if (this.dockingPoints["subscript"] && this.dockingPoints["subscript"].child != null) {
                 expression += "_{" + this.dockingPoints["subscript"].child.formatExpressionAs(format) + "}";

--- a/src/Symbol.ts
+++ b/src/Symbol.ts
@@ -85,7 +85,7 @@ export
     }
 
     /**
-     * Prevents Symbols from being detached from Differentials when the user is
+     * Prevents Symbols from being detached from pre-docked Differentials when the user is
      * unprivileged.
      * 
      * On Isaac, only admins and content editors are privileged.

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -124,6 +124,9 @@ export
     /** Points to which other widgets can dock. See getter below. */
     private _dockingPoints: { [key: string]: DockingPoint; } = {};
 
+    /** Flag for if the widget has been docked by the user (rather than pre-docked from a composite symbol) */
+    private _dockedByUser: boolean = false;
+
     /** Base size of docking points, scaled according to this widget's scale factor. */
     get dockingPointSize(): number {
         return this.scale * this.s.baseDockingPointSize;
@@ -176,6 +179,14 @@ export
      */
     get isDetachable(): boolean {
         return true;
+    }
+
+    get dockedByUser(): boolean {
+        return this._dockedByUser;
+    }
+
+    set dockedByUser(value: boolean) {
+        this._dockedByUser = value;
     }
 
     /**

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -94,6 +94,7 @@ export type WidgetSpec = {
     children?: Array<WidgetSpec>;
     position?: { x: number, y: number };
     expression?: any;
+    dockedByUser?: boolean;
 }
 
 /** A base class for anything visible, draggable, and dockable. */
@@ -377,8 +378,10 @@ export
             expression?: { latex?: string, python?: string },
             properties?: Object,
             children?: { [key: string]: DockingPoint },
+            dockedByUser?: boolean
         } = {
-            type: this.typeAsString
+            type: this.typeAsString,
+            dockedByUser: this.dockedByUser
         };
         if (includeIds) {
             o.id = this.id;

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -428,6 +428,7 @@ export
         let oldParent = this.parentWidget;
         this.currentPlacement = "";
         this.dockedTo = "";
+        this.dockedByUser = false;
         for(let k in this.parentWidget.dockingPoints) {
             let dockingPoint = this.parentWidget?.dockingPoints[k];
             if (dockingPoint?.child == this) {


### PR DESCRIPTION
A few points around weird behaviour of the `isDetachable` property. This was originally just going to be fixing the first point, but more things kept appearing!

- The `sonOfADerivative` property was broken for Differentials that had parents other than a Derivative, stuck in an infinite loop of checking its own parent rather than recursively checking parents. This could cause the app to crash, and is fixed by simply switching the parent being checked.

- For questions like [Mass on a Spring I](https://isaacscience.org/questions/maths_ch7_4_q2) which include Differentials without an argument, a user could dock a Symbol as the argument of this Differential but could never then detach it. This makes sense for composite "pre-docked" Symbols like the `dt` in the denominator to reduce confusion, but we shouldn't block detachment for Symbols that the user has attached themself. I introduce a `dockedByUser` property to fix this.

- Exponents should follow the same logic as arguments for Differentials. Being able to detach `^2` but not `t` from a pre-docked `d^2t` is inconsistent and confusing considering it is otherwise treated as one unit! I add an `isDetachable` case to Num to handle this.

  - The first two points only allow the user more capability so are almost certainly safe. This third one technically slightly restricts capability, but I've checked through all questions this applies to in the content and am happy that this doesn't break any, and I think this is otherwise clearer than before.

- (Also there's an [app issue](https://github.com/isaacphysics/isaac-react-app/pull/1651) in that `isUserPrivileged` was never set for the inequality modal itself, only the inequality text editor)

- (Also also not an isDetachable issue but the app will currently crash if trying to input an exponent on a Derivative denominator that already has an exponent, since the generated LaTeX is invalid. To make it safe, we can wrap the symbol in brackets. There is a [TODO](https://github.com/isaacphysics/inequality/blob/71e689d4e5205b388af89186f1f1c29e9fecf525/src/Symbol.ts#L47-L64) for fixing this more broadly, but this hotfixes the crashing behaviour)

---

I'm happy to sort out releasing this on npm and updating on app once it's approved :)