### PR TITLE
Add mhchem format to the seed's `expression`

### DIFF
--- a/src/Relation.ts
+++ b/src/Relation.ts
@@ -145,25 +145,29 @@ export
     formatExpressionAs(format: string): string {
         let expression = "";
         if (format == "latex") {
+            expression += " " + this.latexSymbol + " ";
             if (this.dockingPoints["right"].child != null) {
-                expression += " " + this.latexSymbol + " " + this.dockingPoints["right"].child.formatExpressionAs(format);
+                expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "python") {
+            expression += " " + this.pythonSymbol + " ";
             if (this.dockingPoints["right"].child != null) {
-                expression += " " + this.pythonSymbol + " " + this.dockingPoints["right"].child.formatExpressionAs(format);
+                expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "subscript") {
             if (this.dockingPoints["right"].child != null) {
                 expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "mhchem") {
+            expression += " " + this.mhchemSymbol + " ";
             if (this.dockingPoints["right"].child != null) {
-                expression += " " + this.mhchemSymbol + " " + this.dockingPoints["right"].child.formatExpressionAs(format);
+                expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         } else if (format == "mathml") {
             let rel = this.mathmlSymbol ? this.mathmlSymbol : this.relation;
+            expression = '<mo>' + rel + "</mo>";
             if (this.dockingPoints["right"].child != null) {
-                expression += '<mo>' + rel + "</mo>" + this.dockingPoints["right"].child.formatExpressionAs(format);
+                expression += this.dockingPoints["right"].child.formatExpressionAs(format);
             }
         }
         return expression;

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -375,7 +375,7 @@ export
             type?: string,
             id?: number,
             position?: { x: number, y: number },
-            expression?: { latex?: string, python?: string },
+            expression?: { latex?: string, python?: string, mhchem?: string },
             properties?: Object,
             children?: { [key: string]: DockingPoint },
             dockedByUser?: boolean
@@ -390,7 +390,8 @@ export
             o.position = { x: p.x, y: p.y };
             o.expression = {
                 latex: this.formatExpressionAs("latex"),
-                python: this.formatExpressionAs("python")
+                python: this.formatExpressionAs("python"),
+                mhchem: this.formatExpressionAs("mhchem"),
             };
         }
         if (processChildren) {

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -390,8 +390,15 @@ export
             o.position = { x: p.x, y: p.y };
             o.expression = {
                 latex: this.formatExpressionAs("latex"),
-                python: this.formatExpressionAs("python"),
-                mhchem: this.formatExpressionAs("mhchem"),
+                ...(["maths", "logic"].includes(this.s.editorMode) 
+                    ? {python: this.formatExpressionAs("python")} 
+                    : {}
+                ),
+                ...(["chemistry", "nuclear"].includes(this.s.editorMode)
+                    ? {mhchem: this.formatExpressionAs("mhchem")}
+                    : {}
+                )
+                
             };
         }
         if (processChildren) {


### PR DESCRIPTION
This may not be required depending on content decision, but this stores the mhchem format result inan object's seed such that the seed could be parsed into a symbolic chemistry question's text entry box on load.