### PR TITLE
Allow non-d differentials to dock as symbols

### DIFF
--- a/src/Differential.ts
+++ b/src/Differential.ts
@@ -44,7 +44,7 @@ class Differential extends Widget {
         this.letter = letter;
 
         this.docksTo = ['operator', 'differential', 'relation'];
-        if (this.letter == "δ" || this.letter == "∆" || this.letter == "Δ") {
+        if (this.letter == "δ" || this.letter == "∆" || this.letter == "Δ") { // The two deltas are different!
             this.docksTo.push('symbol');
         };
     }

--- a/src/Differential.ts
+++ b/src/Differential.ts
@@ -44,6 +44,9 @@ class Differential extends Widget {
         this.letter = letter;
 
         this.docksTo = ['operator', 'differential', 'relation'];
+        if (this.letter == "δ" || this.letter == "∆" || this.letter == "Δ") {
+            this.docksTo.push('symbol');
+        };
     }
 
     get typeAsString(): string {


### PR DESCRIPTION
`Differentials` are not currently allowed to dock as `symbols`, primarily because this could lead to confusion with `Fractions` such as entering "dy/dx" not being equivalent to "Derivative(y, x)". This is also a problem for text-entry, but is a harder problem to solve in that world because they would share a `/` symbol which we can make look identical but define differently in Inequality.

The problem with this is that non-d `Differentials` (Δ, δ) are also not allowed to be entered into `Fractions` in Inequality despite legitimate uses such as [Deriving Kinetic Theory](https://staging.isaacscience.org/questions/phys_linking_31_q) (Part C) as a symbol for the change in time. The only kind of `Derivative` we allow uses d, so it is safe to allow these other `Differentials` to be used in fractions without confusion.

(In the potential future where we expand `Derivatives` to include partial derivatives, this problem would arise again. In this case, we could probably explore having function-like deltas that can interact with `Fractions`, and differential deltas that can interact with `Derivatives`. However this is overly complicated for the current situation)